### PR TITLE
Speed up ContextLogRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ except Exception as exc:
 
 Default value for fill_exception_context param can be changed with env
 
-    export CONTEXT_LOGGING_FILL_EXEPTIONS_DEFAULT=0
+    export CONTEXT_LOGGING_FILL_EXCEPTIONS_DEFAULT=0
 
 ### We can set data to root context that never will be closed
 

--- a/context_logging/config.py
+++ b/context_logging/config.py
@@ -6,8 +6,8 @@ def parse_env_to_bool(val: str) -> bool:
 
 
 class Config:
-    FILL_EXEPTIONS_DEFAULT: bool = parse_env_to_bool(
-        os.getenv('CONTEXT_LOGGING_FILL_EXEPTIONS_DEFAULT', 'yes')
+    FILL_EXCEPTIONS_DEFAULT: bool = parse_env_to_bool(
+        os.getenv('CONTEXT_LOGGING_FILL_EXCEPTIONS_DEFAULT', 'yes')
     )
     LOG_EXECUTION_TIME_DEFAULT: bool = parse_env_to_bool(
         os.getenv('CONTEXT_LOGGING_LOG_EXECUTION_TIME_DEFAULT', 'yes')

--- a/context_logging/log_record.py
+++ b/context_logging/log_record.py
@@ -1,14 +1,13 @@
 import logging
-from copy import deepcopy
 from typing import Any
 
-from .context import current_context
+from .context import get_current_context_shapshot
 
 
 class ContextLogRecord(logging.LogRecord):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.context = deepcopy(current_context) or ''
+        self.context = get_current_context_shapshot()
 
 
 def setup_log_record() -> None:


### PR DESCRIPTION
## Summary

Make `ContextLogRecord` faster.

## Details

The `context` attribute for `ContextLogRecord` is a dict built directly from `_context_data` dicts instead of UserDict/ChainMap proxy. According to measurements this variant collects data ~20 times faster than previous approach. 

Additional fixes:
- faster `_parent_context` emptiness check
- typo in FILL_EXCEPTIONS_DEFAULT

Also pls consider using empty dict instead of empty str for the case of empty current_context

## Check list

- [+] Tests
- [+] README.md changed if needed
